### PR TITLE
Prevent "No Superuser permission declared in manifest" warnings

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -10,6 +10,8 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission
         android:name="android.permission.VIBRATE"/>
+    <uses-permission
+        android:name="android.permission.ACCESS_SUPERUSER"/>
     <application android:label="@string/app_name" android:icon="@drawable/ic_launcher">
         <activity android:name="net.zhuoweizhang.mcpelauncher.LauncherActivity"
                   android:configChanges="orientation|keyboardHidden"


### PR DESCRIPTION
Most Superuser clients display this type of error if no Superuser permission is declared in the manifest.
