### PR TITLE
Fixed crashes with Chest and Furnace methods

### DIFF
--- a/src/net/zhuoweizhang/mcpelauncher/ScriptManager.java
+++ b/src/net/zhuoweizhang/mcpelauncher/ScriptManager.java
@@ -1290,22 +1290,26 @@ public class ScriptManager {
 
 		@JSStaticFunction
 		public static void setChestSlot(int x, int y, int z, int slot, int id, int damage, int amount) {
-			if(getTile(x, y, z) == 54) nativeAddItemChest(x, y, z, slot, id, damage, amount);
+			if(getTile(x, y, z) != 54) throw new IllegalArgumentException("The block at this location is not a chest");
+			nativeAddItemChest(x, y, z, slot, id, damage, amount);
 		}
 
 		@JSStaticFunction
 		public static int getChestSlot(int x, int y, int z, int slot) {
-			if(getTile(x, y, z) == 54) return nativeGetItemChest(x, y, z, slot);
+			if(getTile(x, y, z) != 54) throw new IllegalArgumentException("The block at this location is not a chest");
+			return nativeGetItemChest(x, y, z, slot);
 		}
 
 		@JSStaticFunction
 		public static int getChestSlotData(int x, int y, int z, int slot) {
-			if(getTile(x, y, z) == 54) return nativeGetItemDataChest(x, y, z, slot);
+			if(getTile(x, y, z) != 54) throw new IllegalArgumentException("The block at this location is not a chest");
+			return nativeGetItemDataChest(x, y, z, slot);
 		}
 
 		@JSStaticFunction
 		public static int getChestSlotCount(int x, int y, int z, int slot) {
-			if(getTile(x, y, z) == 54) return nativeGetItemCountChest(x, y, z, slot);
+			if(getTile(x, y, z) != 54) throw new IllegalArgumentException("The block at this location is not a chest");
+			return nativeGetItemCountChest(x, y, z, slot);
 		}
 
 		// KsyMC's additions
@@ -1331,22 +1335,26 @@ public class ScriptManager {
 		
  		@JSFunction
 		public void setFurnaceSlot(int x, int y, int z, int slot, int id, int damage, int amount) {
- 			if(getTile(x, y, z) == 61) nativeAddItemFurnace(x, y, z, slot, id, damage, amount);
+ 			if(getTile(x, y, z) != 61) throw new IllegalArgumentException("The block at this location is not a furnace");
+ 			nativeAddItemFurnace(x, y, z, slot, id, damage, amount);
  		}
  
  		@JSFunction
 		public int getFurnaceSlot(int x, int y, int z, int slot) {
- 			if(getTile(x, y, z) == 61) return nativeGetItemFurnace(x, y, z, slot);
+ 			if(getTile(x, y, z) != 61) throw new IllegalArgumentException("The block at this location is not a furnace");
+ 			return nativeGetItemFurnace(x, y, z, slot);
  		}
  
  		@JSFunction
  		public int getFurnaceSlotData(int x, int y, int z, int slot) {
- 			if(getTile(x, y, z) == 61) return nativeGetItemDataFurnace(x, y, z, slot);
+ 			if(getTile(x, y, z) != 61) throw new IllegalArgumentException("The block at this location is not a furnace");
+ 			return nativeGetItemDataFurnace(x, y, z, slot);
  		}
  
  		@JSFunction
  		public int getFurnaceSlotCount(int x, int y, int z, int slot) {
- 			if(getTile(x, y, z) == 61) return nativeGetItemCountFurnace(x, y, z, slot);
+ 			if(getTile(x, y, z) != 61) throw new IllegalArgumentException("The block at this location is not a furnace");
+ 			return nativeGetItemCountFurnace(x, y, z, slot);
  		}
 		
 		//InusualZ's additions


### PR DESCRIPTION
Fixed crashed...

When there is no Chest at:
setChestSlot()
getChestSlot()
getChestSlotData()
getChestSlotCount()

When there is no Furnace at:
setFurnaceSlot()
getFurnaceSlot()
getFurnaceSlotData()
getFurnaceSlotCount()
